### PR TITLE
Remove manga.tokyo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ A curated list of all things anime - streaming/downloading/reading/tracking/foru
 ### News about Anime
 * [haruhichan.com](https://haruhichan.com/)
 * [animenewsnetwork.com](https://animenewsnetwork.com)
-* [manga.tokyo/](https://manga.tokyo/)
 * [otakuusamagazine.com](https://otakuusamagazine.com)
 * [shikimori.one](https://shikimori.one/) - Russian
 


### PR DESCRIPTION
This page doesn't work anymore
![image](https://user-images.githubusercontent.com/8205043/226467885-ae0c752b-bdf6-48f9-8701-f73206408a8b.png)
